### PR TITLE
Add PHP event calendar example

### DIFF
--- a/php-event-calendar/README.md
+++ b/php-event-calendar/README.md
@@ -1,0 +1,17 @@
+# PHP Event Calendar
+
+This example shows a simple event calendar using PHP and MySQL.
+
+## Setup
+
+1. Import `events.sql` into your MySQL database.
+2. Update the database credentials in `config.php`.
+3. Run the application using a PHP server (e.g., `php -S localhost:8000`).
+4. Open your browser to `http://localhost:8000/php-event-calendar/`.
+
+## Files
+
+- `config.php` – Database connection settings.
+- `index.php` – List events and display form to add a new event.
+- `add_event.php` – Handles inserting a new event.
+- `events.sql` – Example database schema.

--- a/php-event-calendar/add_event.php
+++ b/php-event-calendar/add_event.php
@@ -1,0 +1,14 @@
+<?php
+require 'config.php';
+
+$title = $_POST['title'] ?? '';
+$date  = $_POST['date'] ?? '';
+
+if ($title && $date) {
+    $stmt = $pdo->prepare('INSERT INTO events (title, event_date) VALUES (?, ?)');
+    $stmt->execute([$title, $date]);
+}
+
+header('Location: index.php');
+exit;
+?>

--- a/php-event-calendar/config.php
+++ b/php-event-calendar/config.php
@@ -1,0 +1,17 @@
+<?php
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db   = 'event_calendar';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $e) {
+    die('Connection failed: ' . $e->getMessage());
+}
+?>

--- a/php-event-calendar/events.sql
+++ b/php-event-calendar/events.sql
@@ -1,0 +1,8 @@
+CREATE DATABASE IF NOT EXISTS event_calendar CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE event_calendar;
+
+CREATE TABLE IF NOT EXISTS events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    event_date DATE NOT NULL
+);

--- a/php-event-calendar/index.php
+++ b/php-event-calendar/index.php
@@ -1,0 +1,41 @@
+<?php
+require 'config.php';
+
+// Handle new event submission
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = $_POST['title'] ?? '';
+    $date  = $_POST['date'] ?? '';
+    if ($title && $date) {
+        $stmt = $pdo->prepare('INSERT INTO events (title, event_date) VALUES (?, ?)');
+        $stmt->execute([$title, $date]);
+        header('Location: index.php');
+        exit;
+    }
+}
+
+// Fetch events
+$events = $pdo->query('SELECT * FROM events ORDER BY event_date')->fetchAll();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Event Calendar</title>
+</head>
+<body>
+    <h1>Event Calendar</h1>
+    <h2>Add Event</h2>
+    <form method="post">
+        <label>Title: <input type="text" name="title" required></label><br>
+        <label>Date: <input type="date" name="date" required></label><br>
+        <button type="submit">Add</button>
+    </form>
+
+    <h2>Upcoming Events</h2>
+    <ul>
+        <?php foreach ($events as $event): ?>
+            <li><?= htmlspecialchars($event['event_date']) ?> - <?= htmlspecialchars($event['title']) ?></li>
+        <?php endforeach; ?>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone PHP event calendar example with MySQL

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6858571e44dc832b9040b729eb84fde3